### PR TITLE
Implement rich text link functionality

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1736,3 +1736,171 @@ textarea {
     border: none !important;
     border-color: transparent !important;
 }
+
+/* ========================================
+   RICH TEXT LINK FUNCTIONALITY STYLES
+   ======================================== */
+
+/* Link Modal Styles */
+#linkModal {
+    backdrop-filter: blur(4px);
+}
+
+#linkModal .bg-white {
+    animation: modalSlideIn 0.3s ease-out;
+}
+
+@keyframes modalSlideIn {
+    from {
+        opacity: 0;
+        transform: scale(0.9) translateY(-20px);
+    }
+    to {
+        opacity: 1;
+        transform: scale(1) translateY(0);
+    }
+}
+
+/* Link Tooltip Styles */
+#linkTooltip {
+    animation: tooltipFadeIn 0.2s ease-out;
+    z-index: 1000;
+}
+
+#linkTooltip::before {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 6px solid transparent;
+    border-top-color: white;
+    filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.1));
+}
+
+@keyframes tooltipFadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(5px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+/* Link styling in editor */
+#editor a {
+    text-decoration: underline !important;
+    color: #2563eb !important;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+#editor a:hover {
+    color: #1d4ed8 !important;
+    text-decoration: underline !important;
+}
+
+/* Link styling in post detail view */
+.rich-text-content a {
+    text-decoration: underline !important;
+    color: #2563eb !important;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    position: relative;
+    word-break: break-all;
+}
+
+.rich-text-content a:hover {
+    color: #1d4ed8 !important;
+    text-decoration: underline !important;
+    background-color: rgba(37, 99, 235, 0.1);
+    border-radius: 2px;
+    padding: 1px 2px;
+    margin: -1px -2px;
+}
+
+/* Link hover tooltip for post detail */
+.rich-text-content a:hover::after {
+    content: attr(href);
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(0, 0, 0, 0.8);
+    color: white;
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 12px;
+    white-space: nowrap;
+    z-index: 1000;
+    margin-bottom: 5px;
+    animation: linkTooltipFadeIn 0.2s ease-out;
+}
+
+.rich-text-content a:hover::before {
+    content: '';
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 4px solid transparent;
+    border-top-color: rgba(0, 0, 0, 0.8);
+    z-index: 1000;
+    margin-bottom: 1px;
+}
+
+@keyframes linkTooltipFadeIn {
+    from {
+        opacity: 0;
+        transform: translateX(-50%) translateY(5px);
+    }
+    to {
+        opacity: 1;
+        transform: translateX(-50%) translateY(0);
+    }
+}
+
+/* Toolbar button hover effects */
+.toolbar-btn:hover {
+    background-color: rgba(251, 191, 36, 0.1);
+    transform: scale(1.05);
+}
+
+.toolbar-btn:active {
+    transform: scale(0.95);
+}
+
+/* Modal input focus styles */
+#linkModal input:focus {
+    border-color: #fbbf24;
+    box-shadow: 0 0 0 3px rgba(251, 191, 36, 0.1);
+    outline: none;
+}
+
+/* Tooltip button hover effects */
+#linkTooltip button:hover {
+    transform: scale(1.1);
+}
+
+#linkTooltip button:active {
+    transform: scale(0.95);
+}
+
+/* Responsive adjustments */
+@media (max-width: 640px) {
+    #linkModal .max-w-md {
+        max-width: 95%;
+        margin: 1rem;
+    }
+    
+    #linkTooltip {
+        max-width: 90vw;
+    }
+    
+    .rich-text-content a:hover::after {
+        font-size: 11px;
+        padding: 3px 6px;
+    }
+}

--- a/templates/posts/post_create.html
+++ b/templates/posts/post_create.html
@@ -58,6 +58,12 @@
                                 <button type="button" class="toolbar-btn" onclick="insertBlockquote()" title="Quote">
                                     <span>"</span>
                                 </button>
+                                <button type="button" class="toolbar-btn" onclick="openLinkModal()" title="Insert Link">
+                                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" 
+                                            d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"/>
+                                    </svg>
+                                </button>
                                 <button type="button" class="toolbar-btn" onclick="insertInlineImage()" title="Insert Image">
                                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" 
@@ -162,4 +168,75 @@
         </ul>
     </div>
 </div>
+
+<!-- Link Modal -->
+<div id="linkModal" class="fixed inset-0 z-50 hidden">
+    <!-- Backdrop -->
+    <div class="fixed inset-0 bg-black bg-opacity-50 transition-opacity" onclick="closeLinkModal()"></div>
+    
+    <!-- Modal -->
+    <div class="fixed inset-0 flex items-center justify-center p-4">
+        <div class="bg-white rounded-3xl shadow-2xl max-w-md w-full transform transition-all">
+            <!-- Header -->
+            <div class="flex items-center justify-between p-6 border-b border-gray-100">
+                <h3 class="text-xl font-bold text-gray-800" id="linkModalTitle">Insert Link</h3>
+                <button onclick="closeLinkModal()" class="text-gray-400 hover:text-gray-600 transition-colors">
+                    <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+                    </svg>
+                </button>
+            </div>
+            
+            <!-- Form -->
+            <div class="p-6 space-y-4">
+                <div>
+                    <label for="linkUrl" class="block text-sm font-semibold text-gray-700 mb-2">URL</label>
+                    <input type="url" id="linkUrl" placeholder="https://example.com" 
+                           class="w-full px-4 py-3 rounded-2xl border border-gray-200 focus:outline-none focus:ring-2 focus:ring-amber-400 focus:border-transparent bg-white/80">
+                </div>
+                <div>
+                    <label for="linkText" class="block text-sm font-semibold text-gray-700 mb-2">Link Text</label>
+                    <input type="text" id="linkText" placeholder="Link text" 
+                           class="w-full px-4 py-3 rounded-2xl border border-gray-200 focus:outline-none focus:ring-2 focus:ring-amber-400 focus:border-transparent bg-white/80">
+                </div>
+            </div>
+            
+            <!-- Actions -->
+            <div class="flex flex-col sm:flex-row gap-3 p-6 border-t border-gray-100">
+                <button onclick="insertLink()" 
+                        class="flex-1 bg-gradient-to-r from-amber-400 to-pink-400 text-white py-3 px-6 rounded-2xl hover:shadow-lg transition-all duration-200 font-semibold">
+                    Insert Link
+                </button>
+                <button onclick="closeLinkModal()" 
+                        class="flex-1 glass-effect text-gray-700 py-3 px-6 rounded-2xl hover:bg-white/70 transition-all duration-200 font-semibold">
+                    Cancel
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Link Tooltip -->
+<div id="linkTooltip" class="fixed z-50 hidden">
+    <div class="bg-white rounded-lg shadow-lg border border-gray-200 p-3 max-w-xs">
+        <div class="flex items-center justify-between">
+            <div class="flex-1 min-w-0">
+                <div class="text-sm text-blue-600 underline truncate" id="tooltipUrl"></div>
+            </div>
+            <div class="flex items-center space-x-2 ml-3">
+                <button onclick="editLink()" class="text-blue-500 hover:text-blue-700 transition-colors" title="Edit Link">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
+                    </svg>
+                </button>
+                <button onclick="removeLink()" class="text-red-500 hover:text-red-700 transition-colors" title="Remove Link">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
+                    </svg>
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
 {% endblock %}

--- a/templates/posts/post_edit.html
+++ b/templates/posts/post_edit.html
@@ -61,6 +61,12 @@
                                 <button type="button" class="toolbar-btn" onclick="insertBlockquote()" title="Quote">
                                     <span>"</span>
                                 </button>
+                                <button type="button" class="toolbar-btn" onclick="openLinkModal()" title="Insert Link">
+                                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" 
+                                            d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"/>
+                                    </svg>
+                                </button>
                                 <button type="button" class="toolbar-btn" onclick="insertInlineImage()" title="Insert Image">
                                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" 
@@ -192,4 +198,75 @@
         </ul>
     </div>
 </div>
+
+<!-- Link Modal -->
+<div id="linkModal" class="fixed inset-0 z-50 hidden">
+    <!-- Backdrop -->
+    <div class="fixed inset-0 bg-black bg-opacity-50 transition-opacity" onclick="closeLinkModal()"></div>
+    
+    <!-- Modal -->
+    <div class="fixed inset-0 flex items-center justify-center p-4">
+        <div class="bg-white rounded-3xl shadow-2xl max-w-md w-full transform transition-all">
+            <!-- Header -->
+            <div class="flex items-center justify-between p-6 border-b border-gray-100">
+                <h3 class="text-xl font-bold text-gray-800" id="linkModalTitle">Insert Link</h3>
+                <button onclick="closeLinkModal()" class="text-gray-400 hover:text-gray-600 transition-colors">
+                    <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+                    </svg>
+                </button>
+            </div>
+            
+            <!-- Form -->
+            <div class="p-6 space-y-4">
+                <div>
+                    <label for="linkUrl" class="block text-sm font-semibold text-gray-700 mb-2">URL</label>
+                    <input type="url" id="linkUrl" placeholder="https://example.com" 
+                           class="w-full px-4 py-3 rounded-2xl border border-gray-200 focus:outline-none focus:ring-2 focus:ring-amber-400 focus:border-transparent bg-white/80">
+                </div>
+                <div>
+                    <label for="linkText" class="block text-sm font-semibold text-gray-700 mb-2">Link Text</label>
+                    <input type="text" id="linkText" placeholder="Link text" 
+                           class="w-full px-4 py-3 rounded-2xl border border-gray-200 focus:outline-none focus:ring-2 focus:ring-amber-400 focus:border-transparent bg-white/80">
+                </div>
+            </div>
+            
+            <!-- Actions -->
+            <div class="flex flex-col sm:flex-row gap-3 p-6 border-t border-gray-100">
+                <button onclick="insertLink()" 
+                        class="flex-1 bg-gradient-to-r from-amber-400 to-pink-400 text-white py-3 px-6 rounded-2xl hover:shadow-lg transition-all duration-200 font-semibold">
+                    Insert Link
+                </button>
+                <button onclick="closeLinkModal()" 
+                        class="flex-1 glass-effect text-gray-700 py-3 px-6 rounded-2xl hover:bg-white/70 transition-all duration-200 font-semibold">
+                    Cancel
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Link Tooltip -->
+<div id="linkTooltip" class="fixed z-50 hidden">
+    <div class="bg-white rounded-lg shadow-lg border border-gray-200 p-3 max-w-xs">
+        <div class="flex items-center justify-between">
+            <div class="flex-1 min-w-0">
+                <div class="text-sm text-blue-600 underline truncate" id="tooltipUrl"></div>
+            </div>
+            <div class="flex items-center space-x-2 ml-3">
+                <button onclick="editLink()" class="text-blue-500 hover:text-blue-700 transition-colors" title="Edit Link">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
+                    </svg>
+                </button>
+                <button onclick="removeLink()" class="text-red-500 hover:text-red-700 transition-colors" title="Remove Link">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
+                    </svg>
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
 {% endblock %}

--- a/test_link_functionality.html
+++ b/test_link_functionality.html
@@ -1,0 +1,527 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Link Functionality Test</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+        /* Include the link functionality styles */
+        #linkModal {
+            backdrop-filter: blur(4px);
+        }
+
+        #linkModal .bg-white {
+            animation: modalSlideIn 0.3s ease-out;
+        }
+
+        @keyframes modalSlideIn {
+            from {
+                opacity: 0;
+                transform: scale(0.9) translateY(-20px);
+            }
+            to {
+                opacity: 1;
+                transform: scale(1) translateY(0);
+            }
+        }
+
+        #linkTooltip {
+            animation: tooltipFadeIn 0.2s ease-out;
+            z-index: 1000;
+        }
+
+        #linkTooltip::before {
+            content: '';
+            position: absolute;
+            top: 100%;
+            left: 50%;
+            transform: translateX(-50%);
+            border: 6px solid transparent;
+            border-top-color: white;
+            filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.1));
+        }
+
+        @keyframes tooltipFadeIn {
+            from {
+                opacity: 0;
+                transform: translateY(5px);
+            }
+            to {
+                opacity: 1;
+                transform: translateY(0);
+            }
+        }
+
+        #editor a {
+            text-decoration: underline !important;
+            color: #2563eb !important;
+            cursor: pointer;
+            transition: all 0.2s ease;
+        }
+
+        #editor a:hover {
+            color: #1d4ed8 !important;
+            text-decoration: underline !important;
+        }
+
+        .rich-text-content a {
+            text-decoration: underline !important;
+            color: #2563eb !important;
+            cursor: pointer;
+            transition: all 0.2s ease;
+            position: relative;
+            word-break: break-all;
+        }
+
+        .rich-text-content a:hover {
+            color: #1d4ed8 !important;
+            text-decoration: underline !important;
+            background-color: rgba(37, 99, 235, 0.1);
+            border-radius: 2px;
+            padding: 1px 2px;
+            margin: -1px -2px;
+        }
+
+        .rich-text-content a:hover::after {
+            content: attr(href);
+            position: absolute;
+            bottom: 100%;
+            left: 50%;
+            transform: translateX(-50%);
+            background: rgba(0, 0, 0, 0.8);
+            color: white;
+            padding: 4px 8px;
+            border-radius: 4px;
+            font-size: 12px;
+            white-space: nowrap;
+            z-index: 1000;
+            margin-bottom: 5px;
+            animation: linkTooltipFadeIn 0.2s ease-out;
+        }
+
+        .rich-text-content a:hover::before {
+            content: '';
+            position: absolute;
+            bottom: 100%;
+            left: 50%;
+            transform: translateX(-50%);
+            border: 4px solid transparent;
+            border-top-color: rgba(0, 0, 0, 0.8);
+            z-index: 1000;
+            margin-bottom: 1px;
+        }
+
+        @keyframes linkTooltipFadeIn {
+            from {
+                opacity: 0;
+                transform: translateX(-50%) translateY(5px);
+            }
+            to {
+                opacity: 1;
+                transform: translateX(-50%) translateY(0);
+            }
+        }
+
+        .toolbar-btn:hover {
+            background-color: rgba(251, 191, 36, 0.1);
+            transform: scale(1.05);
+        }
+
+        .toolbar-btn:active {
+            transform: scale(0.95);
+        }
+
+        #linkModal input:focus {
+            border-color: #fbbf24;
+            box-shadow: 0 0 0 3px rgba(251, 191, 36, 0.1);
+            outline: none;
+        }
+
+        #linkTooltip button:hover {
+            transform: scale(1.1);
+        }
+
+        #linkTooltip button:active {
+            transform: scale(0.95);
+        }
+    </style>
+</head>
+<body class="bg-gray-100 p-8">
+    <div class="max-w-4xl mx-auto">
+        <h1 class="text-3xl font-bold mb-8 text-center">Rich Text Link Functionality Test</h1>
+        
+        <!-- Editor Section -->
+        <div class="bg-white rounded-lg shadow-lg p-6 mb-8">
+            <h2 class="text-xl font-semibold mb-4">Rich Text Editor</h2>
+            <div class="rich-text-editor">
+                <div class="toolbar mb-4 p-2 bg-gray-50 rounded-lg flex flex-wrap gap-2">
+                    <button type="button" class="toolbar-btn px-3 py-2 border border-gray-300 rounded hover:bg-gray-100" onclick="formatDoc('bold')" title="Bold">
+                        <strong>B</strong>
+                    </button>
+                    <button type="button" class="toolbar-btn px-3 py-2 border border-gray-300 rounded hover:bg-gray-100" onclick="formatDoc('italic')" title="Italic">
+                        <em>I</em>
+                    </button>
+                    <button type="button" class="toolbar-btn px-3 py-2 border border-gray-300 rounded hover:bg-gray-100" onclick="openLinkModal()" title="Insert Link">
+                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" 
+                                d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"/>
+                        </svg>
+                    </button>
+                </div>
+                
+                <div id="editor" 
+                     class="editor-content min-h-32 p-4 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" 
+                     contenteditable="true" 
+                     placeholder="Type your content here...">
+                    <p>This is a test of the rich text editor. Try selecting some text and clicking the link button to insert a link!</p>
+                </div>
+                
+                <textarea id="hidden-content" style="display: none;"></textarea>
+            </div>
+        </div>
+
+        <!-- Post Detail Section -->
+        <div class="bg-white rounded-lg shadow-lg p-6">
+            <h2 class="text-xl font-semibold mb-4">Post Detail View</h2>
+            <div class="rich-text-content">
+                <p>This is how links will appear in the post detail view. Hover over the links below to see the URL tooltips:</p>
+                <p>Here's a link to <a href="https://stackoverflow.com/">Stack Overflow</a> and another to <a href="https://github.com/">GitHub</a>.</p>
+                <p>You can also have <a href="https://www.google.com/search?q=example">longer links with query parameters</a> that will show the full URL on hover.</p>
+            </div>
+        </div>
+    </div>
+
+    <!-- Link Modal -->
+    <div id="linkModal" class="fixed inset-0 z-50 hidden">
+        <div class="fixed inset-0 bg-black bg-opacity-50 transition-opacity" onclick="closeLinkModal()"></div>
+        
+        <div class="fixed inset-0 flex items-center justify-center p-4">
+            <div class="bg-white rounded-3xl shadow-2xl max-w-md w-full transform transition-all">
+                <div class="flex items-center justify-between p-6 border-b border-gray-100">
+                    <h3 class="text-xl font-bold text-gray-800" id="linkModalTitle">Insert Link</h3>
+                    <button onclick="closeLinkModal()" class="text-gray-400 hover:text-gray-600 transition-colors">
+                        <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+                        </svg>
+                    </button>
+                </div>
+                
+                <div class="p-6 space-y-4">
+                    <div>
+                        <label for="linkUrl" class="block text-sm font-semibold text-gray-700 mb-2">URL</label>
+                        <input type="url" id="linkUrl" placeholder="https://example.com" 
+                               class="w-full px-4 py-3 rounded-2xl border border-gray-200 focus:outline-none focus:ring-2 focus:ring-amber-400 focus:border-transparent bg-white/80">
+                    </div>
+                    <div>
+                        <label for="linkText" class="block text-sm font-semibold text-gray-700 mb-2">Link Text</label>
+                        <input type="text" id="linkText" placeholder="Link text" 
+                               class="w-full px-4 py-3 rounded-2xl border border-gray-200 focus:outline-none focus:ring-2 focus:ring-amber-400 focus:border-transparent bg-white/80">
+                    </div>
+                </div>
+                
+                <div class="flex flex-col sm:flex-row gap-3 p-6 border-t border-gray-100">
+                    <button onclick="insertLink()" 
+                            class="flex-1 bg-gradient-to-r from-amber-400 to-pink-400 text-white py-3 px-6 rounded-2xl hover:shadow-lg transition-all duration-200 font-semibold">
+                        Insert Link
+                    </button>
+                    <button onclick="closeLinkModal()" 
+                            class="flex-1 bg-gray-100 text-gray-700 py-3 px-6 rounded-2xl hover:bg-gray-200 transition-all duration-200 font-semibold">
+                        Cancel
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Link Tooltip -->
+    <div id="linkTooltip" class="fixed z-50 hidden">
+        <div class="bg-white rounded-lg shadow-lg border border-gray-200 p-3 max-w-xs">
+            <div class="flex items-center justify-between">
+                <div class="flex-1 min-w-0">
+                    <div class="text-sm text-blue-600 underline truncate" id="tooltipUrl"></div>
+                </div>
+                <div class="flex items-center space-x-2 ml-3">
+                    <button onclick="editLink()" class="text-blue-500 hover:text-blue-700 transition-colors" title="Edit Link">
+                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
+                        </svg>
+                    </button>
+                    <button onclick="removeLink()" class="text-red-500 hover:text-red-700 transition-colors" title="Remove Link">
+                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
+                        </svg>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        // Include the link functionality JavaScript
+        let currentEditingLink = null;
+        let isEditingMode = false;
+
+        function formatDoc(command, value = null) {
+            const editor = document.getElementById('editor');
+            if (!editor) return;
+            
+            editor.focus();
+            
+            try {
+                if (value !== null) {
+                    document.execCommand(command, false, value);
+                } else {
+                    document.execCommand(command, false, null);
+                }
+                updateHiddenField();
+            } catch (e) {
+                console.error('Error executing command:', e);
+            }
+        }
+
+        function updateHiddenField() {
+            const editor = document.getElementById('editor');
+            const hiddenField = document.getElementById('hidden-content');
+            
+            if (editor && hiddenField) {
+                hiddenField.value = editor.innerHTML;
+            }
+        }
+
+        function openLinkModal() {
+            const modal = document.getElementById('linkModal');
+            const title = document.getElementById('linkModalTitle');
+            const urlInput = document.getElementById('linkUrl');
+            const textInput = document.getElementById('linkText');
+            
+            if (!modal) return;
+            
+            title.textContent = 'Insert Link';
+            urlInput.value = '';
+            textInput.value = '';
+            isEditingMode = false;
+            currentEditingLink = null;
+            
+            const selection = window.getSelection();
+            const selectedText = selection.toString().trim();
+            
+            if (selectedText) {
+                textInput.value = selectedText;
+            }
+            
+            modal.classList.remove('hidden');
+            urlInput.focus();
+        }
+
+        function closeLinkModal() {
+            const modal = document.getElementById('linkModal');
+            if (modal) {
+                modal.classList.add('hidden');
+            }
+        }
+
+        function insertLink() {
+            const urlInput = document.getElementById('linkUrl');
+            const textInput = document.getElementById('linkText');
+            
+            if (!urlInput || !textInput) return;
+            
+            const url = urlInput.value.trim();
+            const text = textInput.value.trim();
+            
+            if (!url) {
+                alert('Please enter a URL');
+                return;
+            }
+            
+            if (!text) {
+                alert('Please enter link text');
+                return;
+            }
+            
+            let finalUrl = url;
+            if (!url.match(/^https?:\/\//)) {
+                finalUrl = 'https://' + url;
+            }
+            
+            const editor = document.getElementById('editor');
+            if (!editor) return;
+            
+            if (isEditingMode && currentEditingLink) {
+                currentEditingLink.href = finalUrl;
+                currentEditingLink.textContent = text;
+                currentEditingLink.style.textDecoration = 'underline';
+                currentEditingLink.style.color = '#2563eb';
+            } else {
+                const selection = window.getSelection();
+                
+                if (selection.rangeCount > 0) {
+                    const range = selection.getRangeAt(0);
+                    range.deleteContents();
+                    
+                    const link = document.createElement('a');
+                    link.href = finalUrl;
+                    link.textContent = text;
+                    link.style.textDecoration = 'underline';
+                    link.style.color = '#2563eb';
+                    link.setAttribute('data-link-id', Date.now().toString());
+                    
+                    range.insertNode(link);
+                    
+                    range.setStartAfter(link);
+                    range.setEndAfter(link);
+                    selection.removeAllRanges();
+                    selection.addRange(range);
+                } else {
+                    const link = document.createElement('a');
+                    link.href = finalUrl;
+                    link.textContent = text;
+                    link.style.textDecoration = 'underline';
+                    link.style.color = '#2563eb';
+                    link.setAttribute('data-link-id', Date.now().toString());
+                    editor.appendChild(link);
+                }
+            }
+            
+            updateHiddenField();
+            closeLinkModal();
+        }
+
+        function showLinkTooltip(linkElement) {
+            const tooltip = document.getElementById('linkTooltip');
+            const urlDisplay = document.getElementById('tooltipUrl');
+            
+            if (!tooltip || !urlDisplay) return;
+            
+            urlDisplay.textContent = linkElement.href;
+            
+            const rect = linkElement.getBoundingClientRect();
+            const tooltipRect = tooltip.getBoundingClientRect();
+            
+            let left = rect.left + (rect.width / 2) - (tooltipRect.width / 2);
+            let top = rect.top - tooltipRect.height - 10;
+            
+            if (left < 10) left = 10;
+            if (left + tooltipRect.width > window.innerWidth - 10) {
+                left = window.innerWidth - tooltipRect.width - 10;
+            }
+            if (top < 10) {
+                top = rect.bottom + 10;
+            }
+            
+            tooltip.style.left = left + 'px';
+            tooltip.style.top = top + 'px';
+            tooltip.classList.remove('hidden');
+            currentEditingLink = linkElement;
+        }
+
+        function hideLinkTooltip() {
+            const tooltip = document.getElementById('linkTooltip');
+            if (tooltip) {
+                tooltip.classList.add('hidden');
+            }
+            currentEditingLink = null;
+        }
+
+        function editLink() {
+            if (!currentEditingLink) return;
+            
+            const modal = document.getElementById('linkModal');
+            const title = document.getElementById('linkModalTitle');
+            const urlInput = document.getElementById('linkUrl');
+            const textInput = document.getElementById('linkText');
+            
+            if (!modal) return;
+            
+            title.textContent = 'Edit Link';
+            urlInput.value = currentEditingLink.href;
+            textInput.value = currentEditingLink.textContent;
+            isEditingMode = true;
+            
+            modal.classList.remove('hidden');
+            urlInput.focus();
+            hideLinkTooltip();
+        }
+
+        function removeLink() {
+            if (!currentEditingLink) return;
+            
+            const linkElement = currentEditingLink;
+            const parent = linkElement.parentNode;
+            
+            const textNode = document.createTextNode(linkElement.textContent);
+            parent.replaceChild(textNode, linkElement);
+            
+            updateHiddenField();
+            hideLinkTooltip();
+        }
+
+        function handleTextSelection() {
+            const selection = window.getSelection();
+            
+            if (selection.rangeCount === 0) {
+                hideLinkTooltip();
+                return;
+            }
+            
+            const range = selection.getRangeAt(0);
+            let node = range.commonAncestorContainer;
+            
+            while (node && node !== document.getElementById('editor')) {
+                if (node.nodeType === Node.ELEMENT_NODE && node.tagName === 'A') {
+                    showLinkTooltip(node);
+                    return;
+                }
+                node = node.parentNode;
+            }
+            
+            const linkElements = range.cloneContents().querySelectorAll('a');
+            if (linkElements.length > 0) {
+                showLinkTooltip(linkElements[0]);
+                return;
+            }
+            
+            hideLinkTooltip();
+        }
+
+        function initLinkFunctionality() {
+            const editor = document.getElementById('editor');
+            if (!editor) return;
+            
+            editor.addEventListener('mouseup', handleTextSelection);
+            editor.addEventListener('keyup', handleTextSelection);
+            editor.addEventListener('selectionchange', handleTextSelection);
+            
+            document.addEventListener('click', function(e) {
+                if (!editor.contains(e.target) && !document.getElementById('linkTooltip')?.contains(e.target)) {
+                    hideLinkTooltip();
+                }
+            });
+            
+            document.addEventListener('keydown', function(e) {
+                if (e.key === 'Escape') {
+                    hideLinkTooltip();
+                    closeLinkModal();
+                }
+            });
+        }
+
+        function initPostDetailLinks() {
+            const postContent = document.querySelector('.rich-text-content');
+            if (!postContent) return;
+            
+            const links = postContent.querySelectorAll('a');
+            links.forEach(link => {
+                link.target = '_blank';
+                link.rel = 'noopener noreferrer';
+            });
+        }
+
+        document.addEventListener('DOMContentLoaded', function() {
+            initLinkFunctionality();
+            initPostDetailLinks();
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Add rich text insert link functionality to the editor, allowing users to insert, edit, and remove links with a modal and interactive tooltip. Links in the post detail view now open in new tabs and display a URL tooltip on hover.

---
<a href="https://cursor.com/background-agent?bcId=bc-801effad-981f-4817-9fd0-4ccbb375001c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-801effad-981f-4817-9fd0-4ccbb375001c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

